### PR TITLE
Fix shared libraries load error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: Test
+
 on: [ push ]
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing
+
 ## Context
 
 This action is built as a composite action, for more details kindly refer

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ runs:
       run: |
         installation_directory=${{ steps.set-installation-directory.outputs.installation_directory }}
         echo "${installation_directory}/bin" >> ${GITHUB_PATH}
+        sudo yum install -y tree
+        cd "${installation_directory}"
+        tree
+        
 
 branding:
   icon: 'code'

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Ensure dependencies of python are installed
+      shell: bash
+      run: |
+        sudo yum groupinstall -y "Development Tools"
+        sudo yum install -y gcc openssl-devel bzip2-devel libffi-devel
+        sudo yum install -y tar gzip wget
+
     - name: Find exact python version
       id: find-exact-python-version
       shell: bash
@@ -51,10 +58,6 @@ runs:
 
         echo "The following python binaries are now available in the PATH"
         ls "${installation_directory}/bin"
-
-        echo "Linking python libraries.."
-        ls "${installation_directory}/lib"
-        ldconfig "${installation_directory}/lib"
 
 branding:
   icon: 'code'

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ runs:
       run: |
         installation_directory=${{ steps.set-installation-directory.outputs.installation_directory }}
         echo "${installation_directory}/bin" >> ${GITHUB_PATH}
+        
+        echo "Linking python libraries.."
+        ls "${installation_directory}/lib"
+        ldconfig "${installation_directory}/lib"
 
 branding:
   icon: 'code'

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ runs:
 
         echo "The following python binaries are now available in the PATH"
         ls "${installation_directory}/bin"
+        
+        echo "Linking python libraries.."
+        ls "${installation_directory}/lib"
+        ldconfig "${installation_directory}/lib"
 
 branding:
   icon: 'code'

--- a/action.yml
+++ b/action.yml
@@ -47,8 +47,11 @@ runs:
       shell: bash
       run: |
         installation_directory=${{ steps.set-installation-directory.outputs.installation_directory }}
-        echo "${installation_directory}/bin" >> ${GITHUB_PATH}
-        
+        echo "${installation_directory}/bin" >> "${GITHUB_PATH}"
+
+        echo "The following python binaries are now available in the PATH"
+        ls "${installation_directory}/bin"
+
         echo "Linking python libraries.."
         ls "${installation_directory}/lib"
         ldconfig "${installation_directory}/lib"

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup python amazon linux'
+name: 'Setup python on amazon linux'
 description: 'Adds support to install python in amazon linux'
 inputs:
   python-version:
@@ -48,10 +48,6 @@ runs:
       run: |
         installation_directory=${{ steps.set-installation-directory.outputs.installation_directory }}
         echo "${installation_directory}/bin" >> ${GITHUB_PATH}
-        sudo yum install -y tree
-        cd "${installation_directory}"
-        tree
-        
 
 branding:
   icon: 'code'

--- a/install-python.sh
+++ b/install-python.sh
@@ -27,7 +27,7 @@ function setup_python() {
     wget "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz"
     tar -zxf "Python-${python_version}.tgz"
     pushd "Python-${python_version}" >/dev/null
-      ./configure --prefix="${python_installation_dir}" --enable-shared LDFLAGS="-Wl,-rpath ${python_installation_dir}/lib" --enable-optimizations
+      ./configure --prefix="${python_installation_dir}"
       make -j 8
       make install
     popd >/dev/null

--- a/install-python.sh
+++ b/install-python.sh
@@ -19,7 +19,8 @@ function setup_python() {
     wget "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz"
     tar -zxf "Python-${python_version}.tgz"
     pushd "Python-${python_version}" >/dev/null
-      ./configure --prefix="${python_installation_dir}" --enable-shared --enable-optimizations
+      # Have not added --enable-optimizations flag because that shoots up the build time by ~5 minutes
+      ./configure --prefix="${python_installation_dir}" --enable-shared
       make -j 8
       make install
     popd >/dev/null

--- a/install-python.sh
+++ b/install-python.sh
@@ -27,7 +27,7 @@ function setup_python() {
     wget "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz"
     tar -zxf "Python-${python_version}.tgz"
     pushd "Python-${python_version}" >/dev/null
-      ./configure --enable-optimizations --prefix="${python_installation_dir}"
+      ./configure --enable-optimizations --enable-shared --prefix="${python_installation_dir}"
       make -j 8
       make install
     popd >/dev/null

--- a/install-python.sh
+++ b/install-python.sh
@@ -27,7 +27,7 @@ function setup_python() {
     wget "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz"
     tar -zxf "Python-${python_version}.tgz"
     pushd "Python-${python_version}" >/dev/null
-      ./configure --enable-optimizations --enable-shared --prefix="${python_installation_dir}"
+      ./configure --prefix="${python_installation_dir}" --enable-shared LDFLAGS="-Wl,-rpath ${python_installation_dir}/lib" --enable-optimizations
       make -j 8
       make install
     popd >/dev/null

--- a/install-python.sh
+++ b/install-python.sh
@@ -4,12 +4,6 @@ set -euo pipefail
 
 # Follows the guidelines from https://realpython.com/installing-python/#how-to-build-python-from-source-code
 
-function setup_build_prerequisites() {
-  sudo yum groupinstall -y "Development Tools"
-  sudo yum install -y tar gzip wget
-  sudo yum install -y gcc openssl-devel bzip2-devel libffi-devel
-}
-
 function set_aliases() {
   ln -sf "${python_installation_dir}/bin/python3" "${python_installation_dir}/bin/python"
   ln -sf "${python_installation_dir}/bin/pip3" "${python_installation_dir}/bin/pip"
@@ -18,8 +12,6 @@ function set_aliases() {
 function setup_python() {
   python_version="$1"
   python_installation_dir="$2"
-
-  setup_build_prerequisites
 
   mkdir -p "${python_installation_dir}"
   temp_dir=$(mktemp -d)

--- a/install-python.sh
+++ b/install-python.sh
@@ -19,7 +19,7 @@ function setup_python() {
     wget "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz"
     tar -zxf "Python-${python_version}.tgz"
     pushd "Python-${python_version}" >/dev/null
-      ./configure --prefix="${python_installation_dir}" --enable-shared
+      ./configure --prefix="${python_installation_dir}" --enable-shared --enable-optimizations
       make -j 8
       make install
     popd >/dev/null

--- a/install-python.sh
+++ b/install-python.sh
@@ -27,7 +27,7 @@ function setup_python() {
     wget "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz"
     tar -zxf "Python-${python_version}.tgz"
     pushd "Python-${python_version}" >/dev/null
-      ./configure --prefix="${python_installation_dir}"
+      ./configure --prefix="${python_installation_dir}" --enable-shared
       make -j 8
       make install
     popd >/dev/null


### PR DESCRIPTION
Fix the following issue in python 3.8.x installation in amazon linux 2 which occurs when cache is being used

```
python3: error while loading shared libraries: libcrypt.so.1: cannot open shared object file: No such file or directory
```