### PR TITLE
Lock UV version to previous working version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: |
         echo "Installing uv.. HOME=${HOME}"
-        curl -LsSf https://astral.sh/uv/install.sh | bash --login
+        curl -LsSf https://astral.sh/uv/0.4.30/install.sh | bash --login
 
     - name: Find desired python version
       id: find-desired-python-version


### PR DESCRIPTION
Short term fix to get some things deployed, but looks like new `uv` download link is pulling `0.5.0` compared to yesterday's `0.4.30` so I'm testing out if this downgrade works.

Will hopefully just fix 0.5.0 after (maybe cuz [Cargo home directory no longer used](https://github.com/astral-sh/uv/releases)?)