### PR TITLE
Use unmanaged uv installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,8 @@ runs:
       run: |
         installation_directory="${HOME}/.setup-python-amazon-linux/uv"
         echo "Installing uv.. installation_directory=${installation_directory}"
-        curl -LsSf https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="${installation_directory}" sh
+        uv_version="0.5.1"
+        curl -LsSf "https://github.com/astral-sh/uv/releases/download/${uv_version}/uv-installer.sh" | UV_UNMANAGED_INSTALL="${installation_directory}" bash --login
         echo "${installation_directory}" >> "${GITHUB_PATH}"
 
     - name: Find desired python version

--- a/action.yml
+++ b/action.yml
@@ -24,8 +24,10 @@ runs:
     - name: Install uv
       shell: bash
       run: |
-        echo "Installing uv.. HOME=${HOME}"
-        curl -LsSf https://astral.sh/uv/install.sh | bash --login
+        installation_directory="${HOME}/.setup-python-amazon-linux/uv"
+        echo "Installing uv.. installation_directory=${installation_directory}"
+        curl -LsSf https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="${installation_directory}" sh
+        echo "${installation_directory}" >> "${GITHUB_PATH}"
 
     - name: Find desired python version
       id: find-desired-python-version


### PR DESCRIPTION
- Uses [unmanaged installation of uv](https://docs.astral.sh/uv/configuration/installer/#unmanaged-installations)
- Locks uv to to the current latest version

Attempts to address #20 and #14 