### PR TITLE
feat: Update uv to 0.8.15

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
       run: |
         installation_directory="${{ github.action_path }}/.setup-python-amazon-linux/uv"
         echo "Installing uv.. installation_directory=${installation_directory}"
-        uv_version="0.7.10"
+        uv_version="0.8.15"
         # HOME is set to foobar till this is resolved https://github.com/astral-sh/uv/issues/6965#issuecomment-2915796022
         curl -LsSf "https://github.com/astral-sh/uv/releases/download/${uv_version}/uv-installer.sh" | HOME="foobar" UV_UNMANAGED_INSTALL="${installation_directory}" bash --login
         echo "${installation_directory}" >> "${GITHUB_PATH}"


### PR DESCRIPTION
## Description

This upgrades the uv version to resolve #25 .

This version of uv isn't able to install python 3.10.18.