### PR TITLE
feat: Allow Skipping Pip Installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: 'Setup python amazon linux'
 description: 'setup-python action for amazon linux self hosted runners'
 inputs:
+  install-pip:
+    description: 'Whether to install pip. Default true.'
+    default: 'true'
   python-version:
     description: 'Version of python to be installed. Reads from python-version-file if unset.'
   python-version-file:
@@ -62,6 +65,7 @@ runs:
         ls "${installation_directory}/bin"
 
     - name: Install pip
+      if: ${{ inputs.install-pip == 'true' }}
       shell: bash
       run: |
         installation_directory="${{ steps.set-installation-directory.outputs.installation_directory }}"


### PR DESCRIPTION
## Description

This change allows consumers to skip pip installation by setting the `install-pip` input to `false` (or really, anything other than `true`).

This can speed up the action by around 5sec for those who don't need to use pip.


closes #29 