### PR TITLE
fix: uv venv error "a virtual environment already exist"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         installation_directory="${{ steps.set-installation-directory.outputs.installation_directory }}"
         desired_python_version="${{ steps.find-desired-python-version.outputs.desired_python_version }}"
 
-        uv venv --python "${desired_python_version}" "${installation_directory}"
+        uv venv --clear --python "${desired_python_version}" "${installation_directory}"
 
     - name: Add python to PATH
       shell: bash


### PR DESCRIPTION
Hello, the recent change of updating the version of `uv` broke our pipelines with the following error:
```
Installing uv.. installation_directory=/opt/actions-runner/_work/_actions/kishaningithub/setup-python-amazon-linux/v1/.setup-python-amazon-linux/uv
downloading uv 0.11.11 aarch64-unknown-linux-gnu
installing to /opt/actions-runner/_work/_actions/kishaningithub/setup-python-amazon-linux/v1/.setup-python-amazon-linux/uv
  uv
  uvx
everything's installed!
Run desired_python_version=$(${GITHUB_ACTION_PATH}/find-desired-python-version.sh "3.13" ".python-version")
desired_python_version=3.13
Run desired_python_version="3.13"
installation_directory=/home/ec2-user/.setup-python-amazon-linux/.python-versions/3.13
Run installation_directory="/home/ec2-user/.setup-python-amazon-linux/.python-versions/3.13"
Using CPython 3.13.13
Creating virtual environment at: /home/ec2-user/.setup-python-amazon-linux/.python-versions/3.13
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at `/home/ec2-user/.setup-python-amazon-linux/.python-versions/3.13`. Use `--clear` to replace it
```

This pr fixes this